### PR TITLE
Adds support for `.` in folder names and support for export statements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
 	"name": "@zoltu/typescript-transformer-append-js-extension",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
 		"@types/node": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
-			"integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
+			"version": "12.6.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+			"integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
 			"dev": true
 		},
 		"arg": {
@@ -38,12 +38,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
-		},
-		"recursive-fs": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/recursive-fs/-/recursive-fs-1.1.2.tgz",
-			"integrity": "sha512-QPFEt5EwzwlHoqYsZc+NkUSyDTQf1Hvq7c/kpQJHi77OSCAiDXI3wfB0J04ZG+ekGHmv37mdR8MDPEshD3/RlQ==",
 			"dev": true
 		},
 		"resolve": {
@@ -94,9 +88,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
 			"dev": true
 		},
 		"yn": {

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
 	"name": "@zoltu/typescript-transformer-append-js-extension",
 	"description": "A TypeScript transformer for use with ttypescript that will append the JS extension to all relative imports that have no extension.",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"repository": {},
 	"license": "Unlicense",
 	"main": "output/index.js",
 	"devDependencies": {
-		"@types/node": "12.0.10",
-		"recursive-fs": "1.1.2",
+		"@types/node": "12.6.8",
 		"ts-node": "8.3.0",
 		"ttypescript": "1.5.7",
-		"typescript": "3.5.2"
+		"typescript": "3.5.3"
 	},
 	"files": [
 		"/output/",
@@ -20,6 +19,6 @@
 	],
 	"scripts": {
 		"build": "tsc",
-		"test": "ttsc -p tests/tsconfig.json"
+		"test": "ttsc -p tests/tsconfig.json && echo Go look at tests/output/index.js to validate transformer did its job, because I'm too lazy to write a real test."
 	}
 }

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,23 +1,30 @@
-import * as typescript from "typescript"
+import * as typescript from 'typescript'
+import * as path from 'path'
 
 const transformer = (_: typescript.Program) => (transformationContext: typescript.TransformationContext) => (sourceFile: typescript.SourceFile) => {
 	function visitNode(node: typescript.Node): typescript.VisitResult<typescript.Node> {
 		if (shouldMutateModuleSpecifier(node)) {
-			const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
-			node = typescript.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
+			if (typescript.isImportDeclaration(node)) {
+				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
+				node = typescript.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
+			} else if (typescript.isExportDeclaration(node)) {
+				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
+				node = typescript.updateExportDeclaration(node, node.decorators, node.modifiers, node.exportClause, newModuleSpecifier)
+			}
 		}
 
 		return typescript.visitEachChild(node, visitNode, transformationContext)
 	}
 
-	function shouldMutateModuleSpecifier(node: typescript.Node): node is typescript.ImportDeclaration & { moduleSpecifier: typescript.StringLiteral } {
-		if (!typescript.isImportDeclaration(node)) return false
+	function shouldMutateModuleSpecifier(node: typescript.Node): node is (typescript.ImportDeclaration | typescript.ExportDeclaration) & { moduleSpecifier: typescript.StringLiteral } {
+		if (!typescript.isImportDeclaration(node) && !typescript.isExportDeclaration(node)) return false
+		if (node.moduleSpecifier === undefined) return false
 		// only when module specifier is valid
 		if (!typescript.isStringLiteral(node.moduleSpecifier)) return false
 		// only when path is relative
 		if (!node.moduleSpecifier.text.startsWith('./') && !node.moduleSpecifier.text.startsWith('../')) return false
 		// only when module specifier has no extension
-		if (node.moduleSpecifier.text.indexOf('.', 2) !== -1) return false
+		if (path.extname(node.moduleSpecifier.text) !== '') return false
 		return true
 	}
 

--- a/tests/source/.baz/index.ts
+++ b/tests/source/.baz/index.ts
@@ -1,0 +1,1 @@
+export function baz() { console.log('baz') }

--- a/tests/source/index.ts
+++ b/tests/source/index.ts
@@ -1,5 +1,10 @@
 import { foo } from './foo'
 import { bar } from './bar.js'
+import { baz } from './.baz/index'
+export { foo } from './foo'
+export { bar } from './bar.js'
+export { baz }
 
 foo()
 bar()
+baz()


### PR DESCRIPTION
There will still be true negatives when a filename contains a dot that isn't used as an extension separator, but solving that requires actually resolving the module which is a hard problem and involves going to disk, which I would like to avoid.

Fixes #1 