### PR TITLE
Fixes a bug in readme/tests where transformer was running too early.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The hope is that eventually TypeScript will [add support for appending the `.js`
 		"compilerOptions": {
 			"module": "es2015",
 			"plugins": [
-				{ "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js" }
+				{ "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true }
 			]
 		},
 	}

--- a/tests/source/index.ts
+++ b/tests/source/index.ts
@@ -4,6 +4,7 @@ import { baz } from './.baz/index'
 export { foo } from './foo'
 export { bar } from './bar.js'
 export { baz }
+export { Apple, Banana, Cherry } from './multiple-types'
 
 foo()
 bar()

--- a/tests/source/multiple-types.ts
+++ b/tests/source/multiple-types.ts
@@ -1,0 +1,3 @@
+export interface Apple { }
+export class Banana {}
+export type Cherry = Apple | Banana

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -15,7 +15,7 @@
 		"esModuleInterop": true,
 		"lib": [ "es2019" ],
 		"plugins": [
-			{ "transform": "../source/index.ts", "afterDeclarations": false }
+			{ "transform": "../source/index.ts", "after": true }
 		]
 	},
 	"include": [


### PR DESCRIPTION
The transformer needs to run after all other transformations.  Importantly, it needs to run after the tranfsormer that visits the source files referenced in an import/export line because once one of these nodes are transformed, the source visiting transformer will refuse to visit them.

Fixes #3 