### PR TITLE
Minor refactor and test case.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Program",
+			"program": "${workspaceFolder}/node_modules/ttypescript/bin/tsc",
+			"cwd": "${workspaceFolder}",
+			"args": ["-p", "tests/tsconfig.json"]
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
 	"requires": true,
 	"dependencies": {
 		"@types/node": {
-			"version": "12.6.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
-			"integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
+			"version": "12.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+			"integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
 			"dev": true
 		},
 		"arg": {
@@ -41,9 +41,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"license": "Unlicense",
 	"main": "output/index.js",
 	"devDependencies": {
-		"@types/node": "12.6.8",
+		"@types/node": "12.7.1",
 		"ts-node": "8.3.0",
 		"ttypescript": "1.5.7",
 		"typescript": "3.5.3"

--- a/source/index.ts
+++ b/source/index.ts
@@ -6,10 +6,10 @@ const transformer = (_: typescript.Program) => (transformationContext: typescrip
 		if (shouldMutateModuleSpecifier(node)) {
 			if (typescript.isImportDeclaration(node)) {
 				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
-				node = typescript.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
+				return typescript.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
 			} else if (typescript.isExportDeclaration(node)) {
 				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
-				node = typescript.updateExportDeclaration(node, node.decorators, node.modifiers, node.exportClause, newModuleSpecifier)
+				return typescript.updateExportDeclaration(node, node.decorators, node.modifiers, node.exportClause, newModuleSpecifier)
 			}
 		}
 

--- a/tests/source/index.ts
+++ b/tests/source/index.ts
@@ -1,8 +1,8 @@
 import { foo } from './foo'
 import { bar } from './bar.js'
 import { baz } from './.baz/index'
-export { foo } from './foo'
-export { bar } from './bar.js'
+export { foo } from "./foo"
+export { bar } from "./bar.js"
 export { baz }
 export { Apple, Banana, Cherry } from './multiple-types'
 


### PR DESCRIPTION
Was in the code working on #3 which turned out to be solved via configuration, but made some other changes in the process that are worth merging.

Add some code to the tests to validate single vs double quotes.  It turns out that TS will emit the original source code if the node was not transformed (which has the quotes still in it) or it will generate code if the node was transformed (which doesn't contain information about original quoting).