### PR TITLE
Adjust readme code style for clarity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The hope is that eventually TypeScript will [add support for appending the `.js`
 		"compilerOptions": {
 			"module": "es2015",
 			"plugins": [
-				{ "transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js", "after": true }
+				{
+					"transform": "@zoltu/typescript-transformer-append-js-extension/output/index.js",
+					"after": true,
+				}
 			]
 		},
 	}


### PR DESCRIPTION
The `"after": true` bit is critical, so we want to make it more obvious to the user so they don't miss it.