### PR TITLE
add node like resolution for directory module specifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,164 @@
 {
 	"name": "@zoltu/typescript-transformer-append-js-extension",
 	"version": "1.0.1",
-	"lockfileVersion": 1,
+	"lockfileVersion": 2,
 	"requires": true,
+	"packages": {
+		"": {
+			"name": "@zoltu/typescript-transformer-append-js-extension",
+			"version": "1.0.1",
+			"license": "Unlicense",
+			"devDependencies": {
+				"@types/node": "14.14.25",
+				"ts-node": "9.1.1",
+				"ttypescript": "1.5.12",
+				"typescript": "4.1.5"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "14.14.25",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+			"integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+			"dev": true
+		},
+		"node_modules/arg": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+			"integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+			"dev": true
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
+		"node_modules/diff": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+			"integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+			"dev": true
+		},
+		"node_modules/path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"node_modules/resolve": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+			"dev": true,
+			"dependencies": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/ts-node": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+			"dev": true,
+			"dependencies": {
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"typescript": ">=2.7"
+			}
+		},
+		"node_modules/ttypescript": {
+			"version": "1.5.12",
+			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
+			"dev": true,
+			"dependencies": {
+				"resolve": ">=1.9.0"
+			},
+			"bin": {
+				"ttsc": "bin/tsc",
+				"ttsserver": "bin/tsserver"
+			},
+			"peerDependencies": {
+				"ts-node": ">=8.0.2",
+				"typescript": ">=3.2.2"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		}
+	},
 	"dependencies": {
 		"@types/node": {
-			"version": "12.7.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-			"integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+			"version": "14.14.25",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
+			"integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
 			"dev": true
 		},
 		"arg": {
@@ -20,6 +171,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
+		},
+		"create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
 		},
 		"diff": {
@@ -56,9 +213,9 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.12",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-			"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+			"version": "0.5.19",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+			"integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -66,37 +223,38 @@
 			}
 		},
 		"ts-node": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-			"integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
 			"dev": true,
 			"requires": {
 				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.6",
-				"yn": "^3.0.0"
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
 			}
 		},
 		"ttypescript": {
-			"version": "1.5.7",
-			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.7.tgz",
-			"integrity": "sha512-qloW8S60+xWVC2bQWldYQfESNFkIgDL5/M+vAOOsuLJ1pQu0SG2vQx5DNJO2nlwSrHxD8cDuF2sVDXg6v3GG3Q==",
+			"version": "1.5.12",
+			"resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.12.tgz",
+			"integrity": "sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==",
 			"dev": true,
 			"requires": {
-				"resolve": "^1.9.0"
+				"resolve": ">=1.9.0"
 			}
 		},
 		"typescript": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-			"integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+			"integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
 			"dev": true
 		},
 		"yn": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.0.tgz",
-			"integrity": "sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
 	"license": "Unlicense",
 	"main": "output/index.js",
 	"devDependencies": {
-		"@types/node": "12.7.1",
-		"ts-node": "8.3.0",
-		"ttypescript": "1.5.7",
-		"typescript": "3.5.3"
+		"@types/node": "14.14.25",
+		"ts-node": "9.1.1",
+		"ttypescript": "1.5.12",
+		"typescript": "4.1.5"
 	},
 	"files": [
 		"/output/",

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,22 +1,14 @@
 import * as typescript from 'typescript'
 import * as path from 'path'
+import * as fs from 'fs'
 
-const transformer = (_: typescript.Program) => (transformationContext: typescript.TransformationContext) => (sourceFile: typescript.SourceFile) => {
-	function visitNode(node: typescript.Node): typescript.VisitResult<typescript.Node> {
-		if (shouldMutateModuleSpecifier(node)) {
-			if (typescript.isImportDeclaration(node)) {
-				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
-				return typescript.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
-			} else if (typescript.isExportDeclaration(node)) {
-				const newModuleSpecifier = typescript.createLiteral(`${node.moduleSpecifier.text}.js`)
-				return typescript.updateExportDeclaration(node, node.decorators, node.modifiers, node.exportClause, newModuleSpecifier)
-			}
-		}
+type ImportExportModuleSpecifier = (typescript.ImportDeclaration | typescript.ExportDeclaration) & { moduleSpecifier: typescript.StringLiteral }
 
-		return typescript.visitEachChild(node, visitNode, transformationContext)
-	}
+const transformer = (program: typescript.Program) => (transformationContext: typescript.TransformationContext) => (sourceFile: typescript.SourceFile) => {
+  const compilerOptions = program.getCompilerOptions()
+  const isNodeModuleResolution = compilerOptions.moduleResolution === typescript.ModuleResolutionKind.NodeJs
 
-	function shouldMutateModuleSpecifier(node: typescript.Node): node is (typescript.ImportDeclaration | typescript.ExportDeclaration) & { moduleSpecifier: typescript.StringLiteral } {
+  function shouldMutateModuleSpecifier(node: typescript.Node): node is ImportExportModuleSpecifier {
 		if (!typescript.isImportDeclaration(node) && !typescript.isExportDeclaration(node)) return false
 		if (node.moduleSpecifier === undefined) return false
 		// only when module specifier is valid
@@ -26,6 +18,43 @@ const transformer = (_: typescript.Program) => (transformationContext: typescrip
 		// only when module specifier has no extension
 		if (path.extname(node.moduleSpecifier.text) !== '') return false
 		return true
+	}
+
+  // use node like module resolution on the module specifier for cases where it points to a directory
+  // containing an index.ts which would ultimately results in module-specifier/index.js)
+  function resolveModuleSpecifier(node: ImportExportModuleSpecifier) {
+    const moduleSpecifier = node.moduleSpecifier.text
+    // only attempt node type resolution when module resolution is node
+    if (isNodeModuleResolution) {
+      // in case the node has prior transforms get the original node
+      const originalNode = typescript.getOriginalNode(node)
+      // try the current node first then revert to original node for source file
+      const sourceFile = node.getSourceFile() || originalNode.getSourceFile()
+      if (sourceFile) {
+        const absoluteModuleSpecifier = path.join(path.dirname(sourceFile.fileName), moduleSpecifier)
+        // if the module specifier is not pointing to a source file, use
+        // node like module resolution to try for <absoluteModuleSpecifier>/index.ts scheme
+        if (!fs.existsSync(`${absoluteModuleSpecifier}.ts`) && fs.existsSync(`${absoluteModuleSpecifier}${path.sep}index.ts`)) {
+          return `${moduleSpecifier}${path.sep}index.js`
+        }
+      }
+    }
+    // default to only append .js
+    return `${moduleSpecifier}.js`
+  }
+
+  function visitNode(node: typescript.Node): typescript.VisitResult<typescript.Node> {
+		if (shouldMutateModuleSpecifier(node)) {
+			if (typescript.isImportDeclaration(node)) {
+        const newModuleSpecifier = typescript.factory.createStringLiteral(resolveModuleSpecifier(node))
+        return typescript.factory.updateImportDeclaration(node, node.decorators, node.modifiers, node.importClause, newModuleSpecifier)
+			} else if (typescript.isExportDeclaration(node)) {
+        const newModuleSpecifier = typescript.factory.createStringLiteral(resolveModuleSpecifier(node))
+				return typescript.factory.updateExportDeclaration(node, node.decorators, node.modifiers, false, node.exportClause, newModuleSpecifier)
+			}
+		}
+
+		return typescript.visitEachChild(node, visitNode, transformationContext)
 	}
 
 	return typescript.visitNode(sourceFile, visitNode)

--- a/tests/source/index.ts
+++ b/tests/source/index.ts
@@ -1,6 +1,8 @@
 import { foo } from './foo'
 import { bar } from './bar.js'
-import { baz } from './.baz/index'
+// NOTE: When tsconfig "moduleResolution": "node" then './.baz' -> './.baz/index.js'
+//       otherwise you need to use './.baz/index'
+import { baz } from './.baz'
 export { foo } from "./foo"
 export { bar } from "./bar.js"
 export { baz }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"target": "es2019",
 		"module": "esnext",
-		"moduleResolution": "classic",
+		"moduleResolution": "node",
 		"rootDir": "source",
 		"outDir": "output",
 		"strict": true,


### PR DESCRIPTION
This PR adds node like resolution for spcific cases where the module specifier is a directory containing an `index.ts` file.  This behavior is only effective when tsconfig `compilerOptions` has `"moduleResolution": "node"` set.

```js
// When tsconfig compilerOptions "moduleResolution": "node" and './foo-lib/index.ts' exists
import { fooFunc } from './foo-lib'
// is transformed to
import { fooFunc } from './foo-lib/index.js'
// Otherwise when tsconfig compilerOptions "moduleResolution": "clasic" or is not set then you need to use
import { fooFunc } from './foo-lib/index'
// instead.
```